### PR TITLE
Refine models for enrolment study

### DIFF
--- a/App/database.py
+++ b/App/database.py
@@ -4,11 +4,14 @@ from flask_migrate import Migrate
 
 db = SQLAlchemy()
 
+
 def get_migrate(app):
     return Migrate(app, db)
 
+
 def create_db():
     db.create_all()
-    
+
+
 def init_db(app):
     db.init_app(app)

--- a/App/models/__init__.py
+++ b/App/models/__init__.py
@@ -1,1 +1,7 @@
 from .user import *
+from .course import *
+from .staff import *
+from .semester import *
+from .course_sem import *
+from .grade import *
+from .allocation import *

--- a/App/models/allocation.py
+++ b/App/models/allocation.py
@@ -1,0 +1,23 @@
+from App.database import db
+
+class Allocation(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    staff_id = db.Column(db.Integer, db.ForeignKey('staff.id'), nullable=False)
+    coursesem_id = db.Column(db.Integer, db.ForeignKey('course_sem.id'), nullable=False)
+    type = db.Column(db.String(20), nullable=False)
+
+    staff = db.relationship('Staff', backref=db.backref('allocations', lazy=True))
+    coursesem = db.relationship('CourseSem', backref=db.backref('allocations', lazy=True))
+
+    def __init__(self, staff_id, coursesem_id, type):
+        self.staff_id = staff_id
+        self.coursesem_id = coursesem_id
+        self.type = type
+
+    def get_json(self):
+        return {
+            'id': self.id,
+            'staff_id': self.staff_id,
+            'coursesem_id': self.coursesem_id,
+            'type': self.type
+        }

--- a/App/models/course.py
+++ b/App/models/course.py
@@ -1,0 +1,18 @@
+from App.database import db
+
+class Course(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(20), unique=True, nullable=False)
+    title = db.Column(db.String(120), nullable=False)
+
+    def __init__(self, code, title):
+        self.code = code
+        self.title = title
+
+    def get_json(self):
+        return {
+            'id': self.id,
+            'code': self.code,
+            'title': self.title
+        }
+

--- a/App/models/course_sem.py
+++ b/App/models/course_sem.py
@@ -1,0 +1,21 @@
+from App.database import db
+
+class CourseSem(db.Model):
+    __tablename__ = 'course_sem'
+    id = db.Column(db.Integer, primary_key=True)
+    course_id = db.Column(db.Integer, db.ForeignKey('course.id'), nullable=False)
+    semester_id = db.Column(db.Integer, db.ForeignKey('semester.id'), nullable=False)
+
+    course = db.relationship('Course', backref=db.backref('course_sems', lazy=True))
+    semester = db.relationship('Semester', backref=db.backref('course_sems', lazy=True))
+
+    def __init__(self, course_id, semester_id):
+        self.course_id = course_id
+        self.semester_id = semester_id
+
+    def get_json(self):
+        return {
+            'id': self.id,
+            'course_id': self.course_id,
+            'semester_id': self.semester_id
+        }

--- a/App/models/grade.py
+++ b/App/models/grade.py
@@ -1,0 +1,25 @@
+from App.database import db
+
+class Grade(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    coursesem_id = db.Column(db.Integer, db.ForeignKey('course_sem.id'), nullable=False)
+    mean_grade = db.Column(db.Float, nullable=True)
+    median_grade = db.Column(db.Float, nullable=True)
+    enrolment = db.Column(db.Integer, nullable=True)
+
+    coursesem = db.relationship('CourseSem', backref=db.backref('grades', lazy=True))
+
+    def __init__(self, coursesem_id, mean_grade=None, median_grade=None, enrolment=None):
+        self.coursesem_id = coursesem_id
+        self.mean_grade = mean_grade
+        self.median_grade = median_grade
+        self.enrolment = enrolment
+
+    def get_json(self):
+        return {
+            'id': self.id,
+            'coursesem_id': self.coursesem_id,
+            'mean_grade': self.mean_grade,
+            'median_grade': self.median_grade,
+            'enrolment': self.enrolment
+        }

--- a/App/models/semester.py
+++ b/App/models/semester.py
@@ -1,0 +1,17 @@
+from App.database import db
+
+class Semester(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    year = db.Column(db.String(9), nullable=False)
+    term = db.Column(db.String(20), nullable=False)
+
+    def __init__(self, year, term):
+        self.year = year
+        self.term = term
+
+    def get_json(self):
+        return {
+            'id': self.id,
+            'year': self.year,
+            'term': self.term
+        }

--- a/App/models/staff.py
+++ b/App/models/staff.py
@@ -1,0 +1,20 @@
+from App.database import db
+
+class Staff(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(80), nullable=False)
+    last_name = db.Column(db.String(80), nullable=False)
+    staff_number = db.Column(db.String(20), unique=True, nullable=False)
+
+    def __init__(self, first_name, last_name, staff_number):
+        self.first_name = first_name
+        self.last_name = last_name
+        self.staff_number = staff_number
+
+    def get_json(self):
+        return {
+            'id': self.id,
+            'first_name': self.first_name,
+            'last_name': self.last_name,
+            'staff_number': self.staff_number
+        }


### PR DESCRIPTION
## Summary
- drop student and enrolment models
- store course results using new Grade schema
- allow academic year strings like `"2022/23"`
- export updated model list

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6855d200de6c832b8b22eedc06501b49